### PR TITLE
v0.4.1

### DIFF
--- a/tui/inbox.go
+++ b/tui/inbox.go
@@ -136,6 +136,15 @@ func (m *Inbox) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		})
 	}
 
+	// New logic to fetch more emails when filtering is active
+	if m.list.FilterState() == list.Filtering && !m.isFetching {
+		m.isFetching = true
+		m.list.Title = "Fetching more emails..."
+		cmds = append(cmds, func() tea.Msg {
+			return FetchMoreEmailsMsg{Offset: uint32(m.emailsCount)}
+		})
+	}
+
 	var cmd tea.Cmd
 	var newModel list.Model
 	newModel, cmd = m.list.Update(msg)

--- a/view/html.go
+++ b/view/html.go
@@ -83,6 +83,20 @@ func ProcessBody(rawBody string) (string, error) {
 		s.ReplaceWithHtml(hyperlink(href, s.Text()))
 	})
 
+	// Format images into terminal hyperlinks
+	doc.Find("img").Each(func(i int, s *goquery.Selection) {
+		src, exists := s.Attr("src")
+		if !exists {
+			return
+		}
+		alt, _ := s.Attr("alt")
+
+		if alt == "" {
+			alt = "Does not contain alt text"
+		}
+		s.ReplaceWithHtml(hyperlink(src, fmt.Sprintf("\n [Click here to view image: %s] \n", alt)))
+	})
+
 	// Get the document's text content, which now includes our formatting
 	text := doc.Text()
 

--- a/view/html.go
+++ b/view/html.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"mime/quotedprintable"
+	"regexp"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -62,6 +63,12 @@ func ProcessBody(rawBody string) (string, error) {
 		s.ReplaceWithHtml(hyperlink(href, s.Text()))
 	})
 
-	// Return the document's text content, which now includes our formatting
-	return doc.Text(), nil
+	// Get the text content, which now includes our formatting
+	text := doc.Text()
+
+	// Collapse more than 2 consecutive newlines into 2
+	re := regexp.MustCompile(`\n{3,}`)
+	text = re.ReplaceAllString(text, "\n\n")
+
+	return text, nil
 }


### PR DESCRIPTION
- b4e16cd fix: image as hyperlink (#4)
- d3e30de fix: hyperlinks in md (#20)
- b138fc2 fix: download emails in filter (#19)
- 7cd9c16 fix: no more than 2 whitespaces (#17)
